### PR TITLE
Fix typo in door opening message

### DIFF
--- a/Door_Locking_System_MC1/MC1.c
+++ b/Door_Locking_System_MC1/MC1.c
@@ -216,7 +216,7 @@ void OPENING_door()
 	UART_sendByte(OPEN_DOOR_COMMAND);
 
 	LCD_clearScreen();
-	LCD_displayStringRowColumn(0,0,"Openning Door...");
+       LCD_displayStringRowColumn(0,0,"Opening Door...");
 
 	UART_recieveByte(); //Door Opened
 }


### PR DESCRIPTION
## Summary
- fix typo in `MC1.c` so display says "Opening Door..."
